### PR TITLE
fixed 404 errors when wordpress is installed into subdir

### DIFF
--- a/lib/classes/OAuth2_API.php
+++ b/lib/classes/OAuth2_API.php
@@ -67,7 +67,7 @@ switch($method){
 			}
 		
 		if ( !is_user_logged_in() ) {
-			wp_redirect( site_url() . '/oauth/login?sso_redirect='.$_GET['client_id'].'&state='.$_GET['state']);
+			wp_redirect( home_url() . '/oauth/login?sso_redirect='.$_GET['client_id'].'&state='.$_GET['state']);
 			exit();
 		}
 		
@@ -189,7 +189,7 @@ function oauth2LoginLayout(){
 					user with a token to the clients site. The client can then take the token and use it to get all the users information for database (AS IF THEY ARE LOGGED IN HERE). 
 			*/
 			if (isset($_GET['sso_redirect']) && $_GET['sso_redirect'] != ''){
-				wp_redirect(site_url() .'/oauth/authorize/?client_id='.$_GET['sso_redirect'].'&state='.$_GET['state'].'&response_type=code');
+				wp_redirect(home_url() .'/oauth/authorize/?client_id='.$_GET['sso_redirect'].'&state='.$_GET['state'].'&response_type=code');
 				
 			}else{
 				$error = '<div class="login_message" style="margin:0 auto;width:50%; font-weight:bold;font-size:14px;color:red;">Incorrect Information</div>';


### PR DESCRIPTION
Fixed 404 errors when wordpress is installed into a subdirectory. Replaced `site_url()` functions with `home_url()` so the subdir is not added to the url as explaned in http://codex.wordpress.org/Function_Reference/site_url#Related 
